### PR TITLE
Add GitHub Skills Activity - Fixes #6

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. First part of our GitHub Certifications program to help with college applications.",
+        "schedule": "Mondays and Fridays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## 🚨 Urgent: Add Missing GitHub Skills Activity

This PR addresses the time-sensitive Issue #6 by adding the GitHub Skills extracurricular activity that was announced by the principal but missing from the signup system.

### What's Changed
- ✅ Added "GitHub Skills" activity to the activities database
- ✅ Configured with appropriate schedule (Mondays and Fridays, 3:30-4:30 PM)
- ✅ Set capacity to 25 participants to handle expected high demand
- ✅ Included description mentioning GitHub Certifications program benefits

### Why This is Important
- 🕐 **Time-sensitive**: Registration deadline is end of this week
- 🎓 **College applications**: Part of GitHub Certifications program
- 👥 **Student demand**: Many students are eager to join after principal's announcement
- 🤝 **Partnership**: New GitHub partnership for practical coding skills

### Testing
- ✅ Verified activity appears in `/activities` API endpoint
- ✅ Confirmed proper JSON structure and data integrity
- ✅ Tested application runs without errors

**Resolves #6**

---

**Student Impact**: This resolves the frustration of students like Hewbie C. (11th Grade) who couldn't find the announced GitHub Skills program for registration.